### PR TITLE
HSCRIPT force closing when changing map though othermeans.

### DIFF
--- a/scripting/acs.sp
+++ b/scripting/acs.sp
@@ -764,6 +764,7 @@ public Action Timer_ChangeMap(Handle timer, DataPack dp) {
 	dp.Reset();
 	dp.ReadString(mapName, sizeof(mapName));
 	
+	ShutDownScriptedMode();
 	ForceChangeLevel(mapName, "sm_votemap Result");
 	
 	return Plugin_Stop;
@@ -1206,6 +1207,8 @@ public Action Timer_CheckEmptyServer(Handle timer, any param) {
 			char mapName[LEN_MAP_FILENAME];
 			ACS_GetFirstMapName(g_iGameMode, 0, mapName, sizeof(mapName));
 			LogMessage("Empty server is running 3-rd map, switching to the first official map!");
+			
+			//ShutDownScriptedMode(); i guess we would need the signiture here :P
 			ForceChangeLevel(mapName, "Empty server with 3-rd map");			
 		}
 	} else {

--- a/scripting/include/l4d2_mission_manager.inc
+++ b/scripting/include/l4d2_mission_manager.inc
@@ -61,3 +61,33 @@ native int LMM_GetInvalidMissionName(int missionIndex, char[] mapName, int lengt
 	LMM APIs become available in OnAllPluginsLoaded().
 **/
 forward void OnLMMUpdateList();
+
+
+/**
+	This can only work while a client is ingame.
+	To call while no clients are not in game requires a signiture @CDirector
+	
+	Call this before you force change level to close HSCRIPT.
+	Any other way of level changing is fine e.g. level transition L4D "callvote missionchange" ect.
+**/
+stock void ShutDownScriptedMode()
+{
+	int iClient = 0;
+	for(int i = 1; i <= MaxClients; i++) 
+	{
+		if(!IsClientInGame(i))
+			continue;
+		
+		iClient = i;
+		break;
+	}
+	
+	if(iClient < 1)
+		return;
+	
+	int iCmdFlags = GetCommandFlags("scripted_mode_shutdown");
+	PrintToServer("[MissionManager] EndingScripted Mode.");
+	SetCommandFlags("scripted_mode_shutdown", iCmdFlags & ~FCVAR_CHEAT);
+	FakeClientCommand(iClient, "scripted_mode_shutdown");
+	SetCommandFlags("scripted_mode_shutdown", iCmdFlags);
+}

--- a/scripting/l4d2_mm_adminmenu.sp
+++ b/scripting/l4d2_mm_adminmenu.sp
@@ -220,6 +220,7 @@ public Action Timer_ChangeMap(Handle timer, DataPack dp) {
 	dp.Reset();
 	dp.ReadString(mapName, sizeof(mapName));
 	
+	ShutDownScriptedMode();
 	ForceChangeLevel(mapName, "Admin forced a map change");
 	
 	return Plugin_Stop;


### PR DESCRIPTION
Hi Rikka.

I made a small change and added closing of `HSCRIPT`, from my understanding of digging thought the binary when forcing map through commands/sourcemod's method, Left 4 dead 2 does not close scripted mode `HSCRIPT` and i assume keeps on opening more instances, I'm unsure of this, the results i'm sure of since that is the only factor that has changed.

For a few years i'v had strange crashing regarding events that is not even touched by my server.
https://crash.limetech.org/kkmcxyjdjl6s

Added stock into `l4d2_mission_manager.inc`

I'v found a fix by executing a `ClientCommand` in the server before we change map called `"scripted_mode_shutdown"` This calls this function.

`CDirectorChallengeMode::ShutdownScriptedMode(eShutdownReason, char const*)`
Linux signiture
`_ZN22CDirectorChallengeMode20ShutdownScriptedModeE15eShutdownReasonPKc`
Window's signiture hunts hurt my brain trying to get signiture for that.

I'v opted out of not calling the function with a signiture i'v no idea how to get windows signiture and it added a dependency if valve break it and it need updating.

Another effect i'v also noticed vscripts working as they are intended no more strange why does this work sometimes moments.

This has been over a month of testing, going from crash every other day to 0.

Hope you can make use of this, many thanks for your revision of mission manager.
