### PR TITLE
Update acs.sp

### DIFF
--- a/scripting/acs.sp
+++ b/scripting/acs.sp
@@ -1223,8 +1223,8 @@ public void CVarChange_MaxFinaleFailures(Handle hCVar, const char[] strOldValue,
 	
 	//If the value was changed, then set it and display a message to the server and players
 	if (iMaxFailures > 0) {
-		PrintToServer("[ACS] ConVar changed: Max Coop finale failures changed to %f", iMaxFailures);
-		PrintToChatAll("[ACS] ConVar changed: Max Coop finale failures changed to %f", iMaxFailures);
+		PrintToServer("[ACS] ConVar changed: Max Coop finale failures changed to %i", iMaxFailures);
+		PrintToChatAll("[ACS] ConVar changed: Max Coop finale failures changed to %i", iMaxFailures);
 	} else {
 		PrintToServer("[ACS] ConVar changed: Max Coop finale failures changed to 0");
 		PrintToChatAll("[ACS] ConVar changed: Max Coop finale failures changed to 0");


### PR DESCRIPTION
I found a problem with this plugin when it displays a change to acs_max_coop_finale_failures. It would display the new value as 0.000000, even if the actual value was something like "3". I fixed it in the source code by changing "%f" to "%i".